### PR TITLE
Remove encoded reward

### DIFF
--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -49,8 +49,7 @@ This integration is useful when you have already created a link reward, and want
           onError: function(err) {
             console.log(err);
           },
-          onRedeem: function(encodedReward) {
-            console.log(encodedReward);
+          onRedeem: function() {
             // Approval not required.
           }
         }

--- a/views/pre_created.haml
+++ b/views/pre_created.haml
@@ -36,7 +36,7 @@
               onError: function(err) {
                 console.log(err);
               },
-              onRedeem: function(encodedReward) {
+              onRedeem: function() {
                 // Approval not required here, since the reward was created via the API.
                 console.log("User redeemed");
               }


### PR DESCRIPTION
Remove references to `encodedReward` arg in documentation so we can begin removing it from embed-sdk and core