### PR TITLE
Update docs for the new redemption flow

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -53,12 +53,12 @@ get '/pre-created' do
 
   # Fetch a reward token to use in the Embed flow
   reward_id = created_order['rewards'].first['id']
-  reward_token = TremendousAPI.post("/rewards/#{reward_id}/generate_embed_token").dig('reward', 'token')
+  reward_embed_token = TremendousAPI.post("/rewards/#{reward_id}/generate_embed_token").dig('reward', 'token')
 
   # Render the reward using the Tremendous Embed flow
   haml :pre_created, locals: {
     tremendous_client_id: ENV['TREMENDOUS_CLIENT_ID'],
-    reward_token: reward_token,
+    reward_embed_token: reward_embed_token,
     created_order: JSON.pretty_generate(created_order)
   }
 end

--- a/app.rb
+++ b/app.rb
@@ -50,12 +50,15 @@ get '/pre-created' do
   # Create a reward
   response = TremendousAPI.post("/orders", body: order)
   created_order = response.parsed_response['order']
-  reward_id = created_order['rewards'].first['id']
 
-  # Create the reward in real time here.
+  # Fetch a reward token to use in the Embed flow
+  reward_id = created_order['rewards'].first['id']
+  reward_token = TremendousAPI.post("/rewards/#{reward_id}/generate_embed_token").dig('reward', 'token')
+
+  # Render the reward using the Tremendous Embed flow
   haml :pre_created, locals: {
     tremendous_client_id: ENV['TREMENDOUS_CLIENT_ID'],
-    reward_id: reward_id,
+    reward_token: reward_token,
     created_order: JSON.pretty_generate(created_order)
   }
 end

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -21,9 +21,23 @@ In order to render the embed, you'll need to include a link to the tremendous em
 
 ## Integration
 
-### Previously created rewards
+This integration is useful when you have already created a link reward, and want the recipient to redeem on your site.
 
-This integration is useful when you have already created a link reward, and want the recipient to redeem on your site. It requires less configuration.
+The Embed flow uses reward tokens that are only valid for 24h.
+These tokens can be generated using the [generate_embed_token](https://developers.tremendous.com/reference/core-rewards-token) endpoint from the Tremendous API.
+
+As an example on how to fetch a token, you can navigate to [app.rb](https://github.com/tremendous-rewards/embed/blob/master/app.rb) in this demo app, where you'll find:
+
+```ruby
+# Fetch a reward token to use in the Embed flow
+reward_id = created_order['rewards'].first['id']
+reward_token = TremendousAPI.post("/rewards/#{reward_id}/generate_embed_token").dig('reward', 'token')
+```
+
+That makes the API call in the backend, using your own API key, and fetches a new temporary token to be passed along to the frontend.
+These tokens shouldn't be permanently stored. Using a temporary token that is past its expiry date will result in an error.
+
+Once the temporary token is fetched, you can pass it to the Embed SDK to start the redeeming flow.
 
 ```html
 <div id="launchpad">Click me to redeem</div>
@@ -37,8 +51,9 @@ This integration is useful when you have already created a link reward, and want
     function redeem() {
 
       client.reward.open(
-        // Pass in the reward_id. Note that this is different from the order_id.
-        "REWARD_ID",
+        // Pass in the temporary reward token.
+        // Note that this is different from the reward_id and the order_id.
+        "REWARD_TOKEN",
         {
           onLoad: function() {
             console.log("It Loaded");

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -31,7 +31,7 @@ As an example on how to fetch a token, you can navigate to [app.rb](https://gith
 ```ruby
 # Fetch a reward token to use in the Embed flow
 reward_id = created_order['rewards'].first['id']
-reward_token = TremendousAPI.post("/rewards/#{reward_id}/generate_embed_token").dig('reward', 'token')
+reward_embed_token = TremendousAPI.post("/rewards/#{reward_id}/generate_embed_token").dig('reward', 'token')
 ```
 
 That makes the API call in the backend, using your own API key, and fetches a new temporary token to be passed along to the frontend.
@@ -53,7 +53,7 @@ Once the temporary token is fetched, you can pass it to the Embed SDK to start t
       client.reward.open(
         // Pass in the temporary reward token.
         // Note that this is different from the reward_id and the order_id.
-        "REWARD_TOKEN",
+        "REWARD_EMBED_TOKEN",
         {
           onLoad: function() {
             console.log("It Loaded");

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -37,7 +37,7 @@ reward_embed_token = TremendousAPI.post("/rewards/#{reward_id}/generate_embed_to
 That makes the API call in the backend, using your own API key, and fetches a new temporary token to be passed along to the frontend.
 These tokens shouldn't be permanently stored. Using a temporary token that is past its expiry date will result in an error.
 
-Once the temporary token is fetched, you can pass it to the Embed SDK to start the redeeming flow.
+Once the temporary token is fetched, you can pass it to the Embed SDK to start the redemption flow.
 
 ```html
 <div id="launchpad">Click me to redeem</div>

--- a/views/pre_created.haml
+++ b/views/pre_created.haml
@@ -24,8 +24,8 @@
 
         function redeem() {
           client.reward.open(
-            // reward token
-            "#{reward_token}",
+            // The reward embed token, fetched with the Tremendous API
+            "#{reward_embed_token}",
             {
               onLoad: function() {
                 console.log("User loaded modal");

--- a/views/pre_created.haml
+++ b/views/pre_created.haml
@@ -24,8 +24,8 @@
 
         function redeem() {
           client.reward.open(
-            // reward ID.
-            "#{reward_id}",
+            // reward token
+            "#{reward_token}",
             {
               onLoad: function() {
                 console.log("User loaded modal");


### PR DESCRIPTION
The redeem flow using the Embed SDK now requires a temporary reward token, instead of the reward ID.

Documentation has been updated to:
- reference the new API endpoint that should be used to fetch the temporary token
- update the demo app, so that it uses the new flow