### PR TITLE
Remove app key dependency and update SDK version

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -57,7 +57,6 @@ get '/pre-created' do
 
   # Render the reward using the Tremendous Embed flow
   haml :pre_created, locals: {
-    tremendous_client_id: ENV['TREMENDOUS_CLIENT_ID'],
     reward_embed_token: reward_embed_token,
     created_order: JSON.pretty_generate(created_order)
   }

--- a/docs/demo.md
+++ b/docs/demo.md
@@ -16,8 +16,6 @@ Visit the [Tremendous Sandbox](https://testflight.tremendous.com) to get your AP
 
 ```sh
 $ touch .env
-$ echo TREMENDOUS_CLIENT_ID=your-client-id >> .env
-$ echo TREMENDOUS_CLIENT_SECRET=your-client-secret >> .env
 $ echo TREMENDOUS_API_KEY=your-api-key >> .env
 $ # make sure it looks right
 $ cat .env

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -5,8 +5,7 @@
 ### API keys
 You can get started immediately with your integration using our sandbox environment. First, sign up to the [Tremendous Sandbox Environment](https://testflight.tremendous.com).
 
-To generate your API key, you'll navigate to Team Settings > Developers. You will need to create both an API Key and a Developer App. The `client_id` from the Developer App will be added to your client as the `TREMENDOUS_CLIENT_ID`.
-
+To generate your API key, you'll navigate to Team Settings > Developers.
 ![API Page](/images/sandbox-keys.png)
 
 Production keys are in the same place in the production environment.
@@ -15,7 +14,7 @@ Production keys are in the same place in the production environment.
 In order to render the embed, you'll need to include a link to the tremendous embed SDK. We have a hosted version on a CDN.
 
 ```html
-<script type="text/javascript" src="https://cdn.tremendous.com/embed/v3.1.0/client.js"/>
+<script type="text/javascript" src="https://cdn.tremendous.com/embed/v4.0.0/client.js"/>
 ```
 
 
@@ -44,7 +43,7 @@ Once the temporary token is fetched, you can pass it to the Embed SDK to start t
 
 <script type="text/javascript">
   document.addEventListener("DOMContentLoaded", function() {
-    var client = Tremendous("TREMENDOUS_CLIENT_ID", {
+    var client = Tremendous({
       domain: Tremendous.domains.SANDBOX
     });
 

--- a/views/pre_created.haml
+++ b/views/pre_created.haml
@@ -1,7 +1,7 @@
 !!!
 %html
   %head
-    %script{type: "text/javascript", src: "https://cdn.tremendous.com/embed/v3.1.0/client.js"}
+    %script{type: "text/javascript", src: "https://cdn.tremendous.com/embed/v4.0.0/client.js"}
     %title Pre-created reward example | Tremendous Embed
 
   %body
@@ -18,7 +18,7 @@
 
     :javascript
       document.addEventListener("DOMContentLoaded", function() {
-        var client = Tremendous("#{tremendous_client_id}", {
+        var client = Tremendous({
           domain: Tremendous.domains.SANDBOX
         });
 


### PR DESCRIPTION
The 4.0.0 SDK version no longer requires a Tremendous Client key. Update the documentation to use the new SDK version.