### PR TITLE
Require bundler/setup

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -1,5 +1,6 @@
+require 'bundler/setup'
 require 'sinatra'
-require "sinatra/reloader"
+require 'sinatra/reloader'
 require 'httparty'
 require 'byebug'
 require 'dotenv/load'


### PR DESCRIPTION
This will remove from the load path everything that's not included in the Gemfile.

Without this, I was getting this error because it was trying to use a different sinatra version I have installed:

```
$ ruby app.rb
Traceback (most recent call last):
        2: from app.rb:3:in `<main>'
        1: from /Users/brianstorti/.asdf/installs/ruby/2.7.6/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:83:in `require'
/Users/brianstorti/.asdf/installs/ruby/2.7.6/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:83:in `require': cannot load such file -- sinatra/reloader (LoadError)
        5: from app.rb:3:in `<main>'
        4: from /Users/brianstorti/.asdf/installs/ruby/2.7.6/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:147:in `require'
        3: from /Users/brianstorti/.asdf/installs/ruby/2.7.6/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:151:in `rescue in require'
        2: from /Users/brianstorti/.asdf/installs/ruby/2.7.6/lib/ruby/2.7.0/rubygems.rb:211:in `try_activate'
        1: from /Users/brianstorti/.asdf/installs/ruby/2.7.6/lib/ruby/2.7.0/rubygems/specification.rb:1369:in `activate'
/Users/brianstorti/.asdf/installs/ruby/2.7.6/lib/ruby/2.7.0/rubygems/specification.rb:2247:in `raise_if_conflicts': Unable to activate sinatra-contrib-2.2.0, because sinatra-3.0.4 conflicts with sinatra (= 2.2.0), mustermann-3.0.0 conflicts with mustermann (~> 1.0), rack-protection-3.0.4 conflicts with rack-protection (= 2.2.0) (Gem::ConflictError)
        6: from app.rb:3:in `<main>'
        5: from /Users/brianstorti/.asdf/installs/ruby/2.7.6/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:147:in `require'
        4: from /Users/brianstorti/.asdf/installs/ruby/2.7.6/lib/ruby/2.7.0/rubygems/core_ext/kernel_require.rb:151:in `rescue in require'
        3: from /Users/brianstorti/.asdf/installs/ruby/2.7.6/lib/ruby/2.7.0/rubygems.rb:210:in `try_activate'
        2: from /Users/brianstorti/.asdf/installs/ruby/2.7.6/lib/ruby/2.7.0/rubygems.rb:217:in `rescue in try_activate'
        1: from /Users/brianstorti/.asdf/installs/ruby/2.7.6/lib/ruby/2.7.0/rubygems/specification.rb:1369:in `activate'
/Users/brianstorti/.asdf/installs/ruby/2.7.6/lib/ruby/2.7.0/rubygems/specification.rb:2247:in `raise_if_conflicts': Unable to activate sinatra-contrib-2.2.0, because sinatra-3.0.4 conflicts with sinatra (= 2.2.0), mustermann-3.0.0 conflicts with mustermann (~> 1.0), rack-protection-3.0.4 conflicts with rack-protection (= 2.2.0) (Gem::ConflictError)
```
